### PR TITLE
Adobe ColdFusion requires that properties are declared first in CFCs

### DIFF
--- a/models/AuthenticationService.cfc
+++ b/models/AuthenticationService.cfc
@@ -1,13 +1,13 @@
 component singleton {
 
-    variables.USER_ID_KEY = "cbauth__userId";
-    variables.USER_KEY = "cbauth__user";
-
     property name="wirebox" inject="wirebox";
     property name="interceptorService" inject="coldbox:interceptorService";
     property name="sessionStorage" inject="SessionStorage@cbstorages";
     property name="requestStorage" inject="RequestStorage@cbstorages";
     property name="userServiceClass" inject="coldbox:setting:userServiceClass@cbauth";
+    
+    variables.USER_ID_KEY = "cbauth__userId";
+    variables.USER_KEY = "cbauth__user";
 
     public void function logout() {
         sessionStorage.deleteVar( USER_ID_KEY );


### PR DESCRIPTION
Users on Adobe ColdFusion will get the error "Property must be defined first within component declaration".  Moving your variables below the properties should address this.