### PR TITLE
Customize storages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,6 @@ language: java
 sudo: required
 jdk:
   - oraclejdk8
-cache:
-  directories:
-    - "$HOME/.CommandBox/artifacts/"
-    - "$HOME/.CommandBox/server/"
 env:
   matrix:
     - ENGINE=adobe@2018

--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -1,10 +1,14 @@
 component {
 
     this.title = "cbauth";
+    this.autoMapModels = false;
+    this.dependencies = [ "cbstorages" ];
 
     function configure() {
         settings = {
-            userServiceClass = ""
+            userServiceClass = "",
+            sessionStorage = "SessionStorage@cbstorages",
+            requestStorage = "RequestStorage@cbstorages"
         };
 
         interceptorSettings = {
@@ -13,6 +17,10 @@ component {
     }
 
     function onLoad() {
+        binder.map( "SessionStorage@cbauth" ).toDSL( settings.sessionStorage );
+        binder.map( "RequestStorage@cbauth" ).toDSL( settings.requestStorage );
+        binder.map( "AuthenticationService@cbauth" ).to( "#moduleMapping#.models.AuthenticationService" );
+
         var helpers = controller.getSetting( "applicationHelper" );
         arrayAppend(
             helpers,
@@ -25,7 +33,7 @@ component {
         controller.setSetting(
             "applicationHelper",
             arrayFilter( controller.getSetting( "applicationHelper" ), function( helper ) {
-                return helper != "#moduleMapping#/helpers/AuthenticationServiceHelpers.cfm"; 
+                return helper != "#moduleMapping#/helpers/AuthenticationServiceHelpers.cfm";
             } )
         );
     }

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ Specify a `userServiceClass` in your `config/ColdBox.cfc` inside `moduleSettings
 
 Additionally, the user component returned by the `retrieve` methods needs to respond to `getId()`.
 
+You can also specify a `sessionStorage` and a `requestStorage` WireBox mapping.
+These will be used inside `AuthenticationService`.  By default, these are
+`SessionStorage@cbstorages` and `RequestStorage@cbstorages` respectively.
+Interfaces are provided in the `models` folder for reference when building
+your own.  (Your storage classes do not need to formally implement the interface.)
+
 ## Usage
 
 You can inject the `authenticationService` using WireBox.

--- a/box.json
+++ b/box.json
@@ -31,8 +31,8 @@
         "testbox":"^2.3.0+00044"
     },
     "installPaths":{
-        "testbox":"testbox",
-        "cbstorages":"modules/cbstorages"
+        "testbox":"testbox/",
+        "cbstorages":"modules/cbstorages/"
     },
     "scripts":{
         "postVersion":"package set location='elpete/cbauth#v`package version`'"

--- a/models/AuthenticationService.cfc
+++ b/models/AuthenticationService.cfc
@@ -2,8 +2,8 @@ component singleton {
 
     property name="wirebox" inject="wirebox";
     property name="interceptorService" inject="coldbox:interceptorService";
-    property name="sessionStorage" inject="CacheStorage@cbstorages";
-    property name="requestStorage" inject="RequestStorage@cbstorages";
+    property name="sessionStorage" inject="SessionStorage@cbauth";
+    property name="requestStorage" inject="RequestStorage@cbauth";
     property name="userServiceClass" inject="coldbox:setting:userServiceClass@cbauth";
     
     variables.USER_ID_KEY = "cbauth__userId";

--- a/models/RequestStorageInterface.cfc
+++ b/models/RequestStorageInterface.cfc
@@ -1,0 +1,6 @@
+interface name="RequestStorageInterface" {
+    public any function getVar( required string name, any defaultValue );
+    public void function setVar( required string name, required any value );
+    public boolean function deleteVar( required string name );
+    public boolean function exists( required string name );
+}

--- a/models/SessionStorageInterface.cfc
+++ b/models/SessionStorageInterface.cfc
@@ -1,0 +1,6 @@
+interface name="SessionStorageInterface" {
+    public any function getVar( required string name, any defaultValue );
+    public void function setVar( required string name, required any value );
+    public boolean function deleteVar( required string name );
+    public boolean function exists( required string name );
+}


### PR DESCRIPTION
cbauth now exposes a `sessionStorage` and a `requestStorage` setting. These expect WireBox mappings and will use them inside inside of `authenticationService.` The defaults provided are `SessionStorage@cbstorages` and `RequestStorage@cbstorages` respectively.